### PR TITLE
Fix MasterKey for SPT 3.9.3

### DIFF
--- a/Live/CWX_MasterKey/MasterKeyPatch.cs
+++ b/Live/CWX_MasterKey/MasterKeyPatch.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+// Sorry.. Also, dependencies must be updated for the project. Not the "AKI" stuff anymore.
 using SPT.Reflection.Patching;
 using EFT;
 

--- a/Live/CWX_MasterKey/MasterKeyPatch.cs
+++ b/Live/CWX_MasterKey/MasterKeyPatch.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
-using Aki.Reflection.Patching;
+using SPT.Reflection.Patching;
 using EFT;
 
 namespace CWX_MasterKey


### PR DESCRIPTION
Hi! I'm pretty new to collaboration on GitHub, actually this is my first pull request.. Anyway I got the MasterKey working on my SPT 3.9.3. Had to update the dependencies for this version (no more 'AKI' references), and change one 'using' line. All the code for the mod still works as it is.

Thank you for lots of great mods!